### PR TITLE
Add Retries with Timeout for RabbitMQ Connection Loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.3.1] - 2025-03-10
+## [1.4.0] - 2025-03-10
 ### Added
 - Introduced new configuration attributes for connection reset handling:
   - `connection_reset_max_retries`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 - Introduced new configuration attributes for connection reset handling:
   - `connection_reset_max_retries`
   - `connection_reset_timeout`
-  - `reset_exceptions`
+  - `connection_reset_exceptions`
 ### Changed
 - Improved handling of `Bunny::ConnectionClosedError`:
   - Added automatic reconnection with retries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.3.1] - 2025-03-10
+### Added
+- Introduced new configuration attributes for connection reset handling:
+  - `connection_reset_max_retries`
+  - `connection_reset_timeout`
+  - `reset_exceptions`
+### Changed
+- Improved handling of `Bunny::ConnectionClosedError`:
+  - Added automatic reconnection with retries.
+  - Implemented configurable timeouts between retries.
+
 ## [1.2.0] - 2025-02-10
 ### Added
 - Add `ExponentialBackoffHandler` for handling errors in rabbit messages

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    rabbit_messaging (1.3.1)
+    rabbit_messaging (1.4.0)
       bunny (~> 2.0)
       kicks
       tainbox

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    rabbit_messaging (1.3.0)
+    rabbit_messaging (1.3.1)
       bunny (~> 2.0)
       kicks
       tainbox

--- a/README.md
+++ b/README.md
@@ -127,6 +127,30 @@ require "rabbit_messaging"
   - `backoff_handler_max_retries` (`Integer`)
 
     Number of retries that `ExponentialBackoffHandler` will use before sending job to the error queue. 5 by default.
+
+  - `connection_reset_exceptions` (`Array`)
+
+    Exceptions for reset connection. Default:  [`Bunny::ConnectionClosedError`].
+
+  ```ruby
+    config.connection_reset_exceptions << MyInterestingException
+  ```
+
+  - `connection_reset_max_retries` (`Integer`)
+
+    Maximum number of reconnection attempts after a connection loss. Default: 10.
+  
+    ```ruby
+      config.connection_reset_max_retries = 20
+    ```
+
+  - `connection_reset_timeout` (`Float`)
+
+    The timeout duration before attempting to reset the connection. Default: 0.2 sec.
+
+    ```ruby
+      config.connection_reset_timeout = 0.2
+    ```
 ---
 
 ### Client

--- a/lib/rabbit.rb
+++ b/lib/rabbit.rb
@@ -30,9 +30,9 @@ module Rabbit
     attribute :skip_publishing_in, default: %i[test development]
     attribute :use_backoff_handler, :Boolean, default: false
     attribute :backoff_handler_max_retries, Integer, default: 6
-    attribute :connection_reset_max_retries, Integer, default: 5
+    attribute :connection_reset_max_retries, Integer, default: 10
     attribute :connection_reset_timeout, Float, default: 0.2
-    attribute :reset_exceptions, Array, default: [Bunny::ConnectionClosedError]
+    attribute :connection_reset_exceptions, Array, default: [Bunny::ConnectionClosedError]
 
     attribute :receive_logger, default: lambda {
       Logger.new(Rabbit.root.join("log", "incoming_rabbit_messages.log"))

--- a/lib/rabbit.rb
+++ b/lib/rabbit.rb
@@ -30,6 +30,9 @@ module Rabbit
     attribute :skip_publishing_in, default: %i[test development]
     attribute :use_backoff_handler, :Boolean, default: false
     attribute :backoff_handler_max_retries, Integer, default: 6
+    attribute :connection_reset_max_retries, Integer, default: 5
+    attribute :connection_reset_timeout, Float, default: 0.2
+    attribute :reset_exceptions, Array, default: [Bunny::ConnectionClosedError]
 
     attribute :receive_logger, default: lambda {
       Logger.new(Rabbit.root.join("log", "incoming_rabbit_messages.log"))

--- a/lib/rabbit/publishing.rb
+++ b/lib/rabbit/publishing.rb
@@ -70,7 +70,7 @@ module Rabbit
     end
 
     def reinitialize_channels_pool
-      @pool = nil
+      MUTEX.synchronize { @pool = ChannelsPool.new(create_client) }
     end
   end
 end

--- a/lib/rabbit/publishing.rb
+++ b/lib/rabbit/publishing.rb
@@ -23,11 +23,11 @@ module Rabbit
 
           log msg
         end
-      rescue *Rabbit.config.reset_exceptions => error
+      rescue *Rabbit.config.connection_reset_exceptions => error
         attempt += 1
         if attempt <= Rabbit.config.connection_reset_max_retries
           sleep(Rabbit.config.connection_reset_timeout)
-          @pool = nil
+          reinitialize_channels_pool
           retry
         else
           raise error
@@ -67,6 +67,10 @@ module Rabbit
       ]
 
       @logger.debug "#{metadata.join ' / '}: #{JSON.dump(message.data)}"
+    end
+
+    def reinitialize_channels_pool
+      @pool = nil
     end
   end
 end

--- a/lib/rabbit/publishing.rb
+++ b/lib/rabbit/publishing.rb
@@ -10,23 +10,35 @@ module Rabbit
 
     MUTEX = Mutex.new
 
-    def publish(msg)
+    def publish(msg) # rubocop:disable Metrics/MethodLength
       return if Rabbit.config.skip_publish?
 
-      pool.with_channel msg.confirm_select? do |ch|
-        ch.basic_publish *msg.basic_publish_args
+      attempt = 0
+      begin
+        pool.with_channel msg.confirm_select? do |ch|
+          ch.basic_publish *msg.basic_publish_args
 
-        raise MessageNotDelivered, "RabbitMQ message not delivered: #{msg}" \
-          if msg.confirm_select? && !ch.wait_for_confirms
+          raise MessageNotDelivered, "RabbitMQ message not delivered: #{msg}" \
+            if msg.confirm_select? && !ch.wait_for_confirms
 
-        log msg
+          log msg
+        end
+      rescue *Rabbit.config.reset_exceptions => error
+        attempt += 1
+        if attempt <= Rabbit.config.connection_reset_max_retries
+          sleep(Rabbit.config.connection_reset_timeout)
+          @pool = nil
+          retry
+        else
+          raise error
+        end
+      rescue Timeout::Error
+        raise MessageNotDelivered, <<~MESSAGE
+          Timeout while sending message #{msg}. Possible reasons:
+            - #{msg.real_exchange_name} exchange is not found
+            - RabbitMQ is extremely high loaded
+        MESSAGE
       end
-    rescue Timeout::Error
-      raise MessageNotDelivered, <<~MESSAGE
-        Timeout while sending message #{msg}. Possible reasons:
-          - #{msg.real_exchange_name} exchange is not found
-          - RabbitMQ is extremely high loaded
-      MESSAGE
     end
 
     def pool

--- a/lib/rabbit/version.rb
+++ b/lib/rabbit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rabbit
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end

--- a/lib/rabbit/version.rb
+++ b/lib/rabbit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rabbit
-  VERSION = "1.3.1"
+  VERSION = "1.4.0"
 end

--- a/spec/units/rabbit_spec.rb
+++ b/spec/units/rabbit_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Rabbit do
     end
   end
 
-  context "retries on reset_exceptions" do
+  context "retries on connection_reset_exceptions" do
     let(:realtime) { true }
     let(:max_retries) { 2 }
     let(:timeout) { 0.1 }
@@ -113,7 +113,7 @@ RSpec.describe Rabbit do
       Rabbit::Publishing.instance_variable_set(:@logger, nil)
     end
 
-    it "retries publishing when an exception from reset_exceptions occurs" do
+    it "retries publishing when an exception from connection_reset_exceptions occurs" do
       attempt = 0
 
       allow(channel).to receive(:basic_publish) do |*args|


### PR DESCRIPTION
- Introduced new config attributes:
  - `connection_reset_max_retries`
  - `connection_reset_timeout`
  - `connection_reset_exceptions`
- Implemented automatic reconnection on `Bunny::ConnectionClosedError`.
- Added retry mechanism with configurable timeouts.