### PR TITLE
Разделение log message на части

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.5.0] - 2025-05-19
+### Added
+- Added ability to split log message into parts
+- Optional `logger_message_size_limit` config for message size limit
+
 ## [1.4.0] - 2025-03-10
 ### Added
 - Introduced new configuration attributes for connection reset handling:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    rabbit_messaging (1.4.0)
+    rabbit_messaging (1.5.0)
       bunny (~> 2.0)
       kicks
       tainbox

--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ require "rabbit_messaging"
     ```ruby
       config.connection_reset_timeout = 0.2
     ```
+
+  - `logger_message_size_limit` (`Integer`)
+
+    Maximum logger message size. Split message to parts if message is more than limit. Default: 9500.
+
+    ```ruby
+      config.logger_message_size_limit = 9500
+    ```
 ---
 
 ### Client

--- a/lib/rabbit.rb
+++ b/lib/rabbit.rb
@@ -33,7 +33,7 @@ module Rabbit
     attribute :connection_reset_max_retries, Integer, default: 10
     attribute :connection_reset_timeout, Float, default: 0.2
     attribute :connection_reset_exceptions, Array, default: [Bunny::ConnectionClosedError]
-    attribute :logger_message_size_limit, Integer, default: 10_000
+    attribute :logger_message_size_limit, Integer, default: 9_500
 
     attribute :receive_logger, default: lambda {
       Logger.new(Rabbit.root.join("log", "incoming_rabbit_messages.log"))

--- a/lib/rabbit.rb
+++ b/lib/rabbit.rb
@@ -33,6 +33,7 @@ module Rabbit
     attribute :connection_reset_max_retries, Integer, default: 10
     attribute :connection_reset_timeout, Float, default: 0.2
     attribute :connection_reset_exceptions, Array, default: [Bunny::ConnectionClosedError]
+    attribute :logger_message_size_limit, Integer, default: 10_000
 
     attribute :receive_logger, default: lambda {
       Logger.new(Rabbit.root.join("log", "incoming_rabbit_messages.log"))

--- a/lib/rabbit/helper.rb
+++ b/lib/rabbit/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rabbit
   class Helper
     def self.generate_message(message_part, parts, index)

--- a/lib/rabbit/helper.rb
+++ b/lib/rabbit/helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rabbit
-  class Helper
+  module Helper
     def self.generate_message(message_part, parts, index)
       if parts == 1
         message_part

--- a/lib/rabbit/helper.rb
+++ b/lib/rabbit/helper.rb
@@ -1,0 +1,15 @@
+module Rabbit
+  class Helper
+    def self.generate_message(message_part, parts, index)
+      if parts == 1
+        message_part
+      elsif index.zero?
+        "#{message_part}..."
+      elsif index == parts - 1
+        "...#{message_part}"
+      else
+        "...#{message_part}..."
+      end
+    end
+  end
+end

--- a/lib/rabbit/publishing.rb
+++ b/lib/rabbit/publishing.rb
@@ -71,8 +71,8 @@ module Rabbit
 
       message_parts.each_with_index do |message_part, index|
         if message_parts.size == 1
-          msg = "#{message_part}"
-        elsif index == 0
+          msg = message_part
+        elsif index.zero?
           msg = "#{message_part}..."
         elsif index == message_parts.size - 1
           msg = "...#{message_part}"

--- a/lib/rabbit/publishing.rb
+++ b/lib/rabbit/publishing.rb
@@ -70,17 +70,8 @@ module Rabbit
                           .scan(/.{1,#{Rabbit.config.logger_message_size_limit}}/)
 
       message_parts.each_with_index do |message_part, index|
-        if message_parts.size == 1
-          msg = message_part
-        elsif index.zero?
-          msg = "#{message_part}..."
-        elsif index == message_parts.size - 1
-          msg = "...#{message_part}"
-        else
-          msg = "...#{message_part}..."
-        end
-
-        @logger.debug "#{metadata.join ' / '}: #{msg}"
+        message = Rabbit::Helper.generate_message(message_part, message_parts.size, index)
+        @logger.debug "#{metadata.join ' / '}: #{message}"
       end
     end
 

--- a/lib/rabbit/publishing.rb
+++ b/lib/rabbit/publishing.rb
@@ -66,7 +66,12 @@ module Rabbit
         message.event, message.confirm_select? ? "confirm" : "no-confirm"
       ]
 
-      @logger.debug "#{metadata.join ' / '}: #{JSON.dump(message.data)}"
+      message_parts = JSON.dump(message.data)
+                          .scan(/.{1,#{Rabbit.config.logger_message_size_limit}}/)
+
+      message_parts.each do |message_part|
+        @logger.debug "#{metadata.join ' / '}: #{message_part}"
+      end
     end
 
     def reinitialize_channels_pool

--- a/lib/rabbit/publishing.rb
+++ b/lib/rabbit/publishing.rb
@@ -69,8 +69,18 @@ module Rabbit
       message_parts = JSON.dump(message.data)
                           .scan(/.{1,#{Rabbit.config.logger_message_size_limit}}/)
 
-      message_parts.each do |message_part|
-        @logger.debug "#{metadata.join ' / '}: #{message_part}"
+      message_parts.each_with_index do |message_part, index|
+        if message_parts.size == 1
+          msg = "#{message_part}"
+        elsif index == 0
+          msg = "#{message_part}..."
+        elsif index == message_parts.size - 1
+          msg = "...#{message_part}"
+        else
+          msg = "...#{message_part}..."
+        end
+
+        @logger.debug "#{metadata.join ' / '}: #{msg}"
       end
     end
 

--- a/lib/rabbit/receiving/receive.rb
+++ b/lib/rabbit/receiving/receive.rb
@@ -5,6 +5,7 @@ require "tainbox"
 require "rabbit"
 require "rabbit/receiving/queue"
 require "rabbit/receiving/job"
+require "rabbit/helper"
 
 class Rabbit::Receiving::Receive
   include Tainbox
@@ -24,18 +25,10 @@ class Rabbit::Receiving::Receive
     message_parts = message.scan(/.{1,#{Rabbit.config.logger_message_size_limit}}/)
 
     message_parts.each_with_index do |message_part, index|
-      if message_parts.size == 1
-        msg = message_part
-      elsif index.zero?
-        msg = "#{message_part}..."
-      elsif index == message_parts.size - 1
-        msg = "...#{message_part}"
-      else
-        msg = "...#{message_part}..."
-      end
+      message = Rabbit::Helper.generate_message(message_part, message_parts.size, index)
 
       Rabbit.config.receive_logger.debug(
-        [msg, delivery_info, arguments].join(" / "),
+        [message, delivery_info, arguments].join(" / "),
       )
     end
   end

--- a/lib/rabbit/receiving/receive.rb
+++ b/lib/rabbit/receiving/receive.rb
@@ -21,9 +21,13 @@ class Rabbit::Receiving::Receive
   end
 
   def log!
-    Rabbit.config.receive_logger.debug(
-      [message, delivery_info, arguments].join(" / "),
-    )
+    message_parts = message.scan(/.{1,#{Rabbit.config.logger_message_size_limit}}/)
+
+    message_parts.each do |message_part|
+      Rabbit.config.receive_logger.debug(
+        [message_part, delivery_info, arguments].join(" / "),
+      )
+    end
   end
 
   def process_message

--- a/lib/rabbit/receiving/receive.rb
+++ b/lib/rabbit/receiving/receive.rb
@@ -25,8 +25,8 @@ class Rabbit::Receiving::Receive
 
     message_parts.each_with_index do |message_part, index|
       if message_parts.size == 1
-        msg = "#{message_part}"
-      elsif index == 0
+        msg = message_part
+      elsif index.zero?
         msg = "#{message_part}..."
       elsif index == message_parts.size - 1
         msg = "...#{message_part}"

--- a/lib/rabbit/receiving/receive.rb
+++ b/lib/rabbit/receiving/receive.rb
@@ -23,9 +23,19 @@ class Rabbit::Receiving::Receive
   def log!
     message_parts = message.scan(/.{1,#{Rabbit.config.logger_message_size_limit}}/)
 
-    message_parts.each do |message_part|
+    message_parts.each_with_index do |message_part, index|
+      if message_parts.size == 1
+        msg = "#{message_part}"
+      elsif index == 0
+        msg = "#{message_part}..."
+      elsif index == message_parts.size - 1
+        msg = "...#{message_part}"
+      else
+        msg = "...#{message_part}..."
+      end
+
       Rabbit.config.receive_logger.debug(
-        [message_part, delivery_info, arguments].join(" / "),
+        [msg, delivery_info, arguments].join(" / "),
       )
     end
   end

--- a/lib/rabbit/version.rb
+++ b/lib/rabbit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Rabbit
-  VERSION = "1.4.0"
+  VERSION = "1.5.0"
 end

--- a/spec/units/rabbit_spec.rb
+++ b/spec/units/rabbit_spec.rb
@@ -73,11 +73,11 @@ RSpec.describe Rabbit do
 
       expect(publish_logger).to receive(:debug).with(<<~MSG.strip)
         test_group_id.test_project_id.some_exchange / some_queue / {"foo":"bar"} / some_event / \
-        confirm: {"hello":"
+        confirm: {"hello":"...
       MSG
       expect(publish_logger).to receive(:debug).with(<<~MSG.strip)
         test_group_id.test_project_id.some_exchange / some_queue / {"foo":"bar"} / some_event / \
-        confirm: world"}
+        confirm: ...world"}
       MSG
       described_class.publish(message_options)
     end

--- a/spec/units/rabbit_spec.rb
+++ b/spec/units/rabbit_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Rabbit do
       allow(channel).to receive(:open?).and_return(true)
 
       allow(Rabbit.config).to receive(:publish_logger) { publish_logger }
-      allow(Rabbit.config).to receive(:logger_message_size_limit) { 10 }
+      allow(Rabbit.config).to receive(:logger_message_size_limit).and_return(10)
 
       expect(channel).to receive(:confirm_select).once
       allow(channel).to receive(:wait_for_confirms).and_return(true)

--- a/spec/units/rabbit_spec.rb
+++ b/spec/units/rabbit_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Rabbit do
       allow(channel).to receive(:open?).and_return(true)
 
       allow(Rabbit.config).to receive(:publish_logger) { publish_logger }
+      allow(Rabbit.config).to receive(:logger_message_size_limit) { 10 }
 
       expect(channel).to receive(:confirm_select).once
       allow(channel).to receive(:wait_for_confirms).and_return(true)
@@ -70,9 +71,13 @@ RSpec.describe Rabbit do
         expect(Rabbit::Publishing::Job).not_to receive(:perform_later)
       end
 
-      expect(publish_logger).to receive(:debug).with(<<~MSG.strip).once
+      expect(publish_logger).to receive(:debug).with(<<~MSG.strip)
         test_group_id.test_project_id.some_exchange / some_queue / {"foo":"bar"} / some_event / \
-        confirm: {"hello":"world"}
+        confirm: {"hello":"
+      MSG
+      expect(publish_logger).to receive(:debug).with(<<~MSG.strip)
+        test_group_id.test_project_id.some_exchange / some_queue / {"foo":"bar"} / some_event / \
+        confirm: world"}
       MSG
       described_class.publish(message_options)
     end


### PR DESCRIPTION
Добавил возможность разделения логов на части, так как может прилетать батч большого размера. По умолчанию сообщения будут разделяться на части по 10к символов